### PR TITLE
added root route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   # See how all your routes lay out with "rake routes".
 
   # You can have the root of your site routed with "root"
-  # root 'welcome#index'
+  root 'movies#index'
 
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'


### PR DESCRIPTION
README states: "Now you should be able to navigate to your app's URL. heroku open opens your browser to that URL in case you forgot it."  This ("heroku open") will not work on Heroku unless there is a root route defined.  (without a root route open has to add "/movies" to the default URL)

https://www.pivotaltracker.com/story/show/107709426