### PR TITLE
tzinfo windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,13 +34,17 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 
 gem 'themoviedb'
 
+# Window support
+gem 'tzinfo'
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
 
   gem 'rspec-rails'
   gem 'guard-rspec'
-  
+
   # Use sqlite3 as the database for Active Record
   gem 'sqlite3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,6 +236,8 @@ DEPENDENCIES
   sqlite3
   themoviedb
   turbolinks
+  tzinfo
+  tzinfo-data
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
 
@@ -243,4 +245,4 @@ RUBY VERSION
    ruby 2.4.0p0
 
 BUNDLED WITH
-   1.16.1
+   1.17.3


### PR DESCRIPTION
Adding tzinfo, required for windows users. Several students reported being unable to run the app without adding these gems manually to their Gemfile.